### PR TITLE
Two fixes when loading saved results

### DIFF
--- a/pyOptimalEstimation/pyOEcore.py
+++ b/pyOptimalEstimation/pyOEcore.py
@@ -1291,8 +1291,8 @@ def _oeDict2Object(oeDict):
         oeDict.pop("x_a"),
         oeDict.pop("S_a"),
         oeDict.pop("y_vars"),
-        oeDict.pop("S_y"),
         oeDict.pop("y_obs"),
+        oeDict.pop("S_y"),
         None
     )
     for kk in oeDict.keys():

--- a/pyOptimalEstimation/pyOEcore.py
+++ b/pyOptimalEstimation/pyOEcore.py
@@ -1210,7 +1210,7 @@ class optimalEstimation(object):
         return summary
 
 
-def optimalEstimation_loadResults(fname, allow_pickle=False):
+def optimalEstimation_loadResults(fname, allow_pickle=True):
     r'''
     Helper function to load a saved pyOptimalEstimation object
 

--- a/pyOptimalEstimation/pyOEcore.py
+++ b/pyOptimalEstimation/pyOEcore.py
@@ -1210,7 +1210,7 @@ class optimalEstimation(object):
         return summary
 
 
-def optimalEstimation_loadResults(fname):
+def optimalEstimation_loadResults(fname, allow_pickle=False):
     r'''
     Helper function to load a saved pyOptimalEstimation object
 
@@ -1224,7 +1224,7 @@ def optimalEstimation_loadResults(fname):
     pyOptimalEstimation object
       pyOptimalEstimation obtained from file.
     '''
-    oeDict = np.load(fname)
+    oeDict = np.load(fname, allow_pickle=allow_pickle)
     oe = _oeDict2Object(oeDict.tolist())
     return oe
 


### PR DESCRIPTION
I had two issues when loading results previously saved with oe.saveResults()
The pickled file won't load without explicitly allow loading pickled files, this is since Numpy version 1.16.3: Made default False in response to CVE-2019-6446.
The second issue was due to  _oeDict2Object() calling the init with variables S_y and y_obs in the wrong order.

