### PR TITLE
Update pyOpEst with faster options for Jacobian computation

### DIFF
--- a/pyOptimalEstimation/pyOEcore.py
+++ b/pyOptimalEstimation/pyOEcore.py
@@ -544,7 +544,7 @@ class optimalEstimation(object):
         # Assemble  Jacobian Dataframe:
         
         jacobian = pd.DataFrame(jac_numpy, 
-                  index=self.y_vars, columns=disturbedKeys)
+                  index=self.y_vars, columns=disturbedKeys)      
 
         jacobian[np.isnan(jacobian) | np.isinf(jacobian)] = 0.
         jacobian_x = jacobian[["disturbed %s" % s for s in self.x_vars]]
@@ -625,15 +625,21 @@ class optimalEstimation(object):
 
         for i in range(maxIter):
             
+            #startTimeJac = time.time()
+            
             if (self.rttovK != None): # then RTTOV's K model is used
             
                 self.K_i[i], self.K_b_i[i]  = self.getJacobian_RTTOV(
                     pd.concat((self.x_i[i], self.b_p)), self.y_i[i]) 
-                                                                
+                                                                                                                    
             else:
             
                 self.K_i[i], self.K_b_i[i]  = self.getJacobian_v1(
                     pd.concat((self.x_i[i], self.b_p)), self.y_i[i])
+            
+            #print("%.2f s , TimeJac" % (time.time()-startTimeJac))  
+            
+            #startTimeRest = time.time()
             
             if np.sum(self.S_b.shape) > 0:
                 S_ep_b = self.K_b_i[i].values.dot(
@@ -807,6 +813,7 @@ class optimalEstimation(object):
                               time.time()-startTime, i, self.dgf_i[i],
                               self.x_n, usingTest, self.d_i2[i]))
 
+            #print("%.2f s , TimeRest" % (time.time()-startTimeRest)) 
 
         self.K_i = self.K_i[:i+1]
         self.K_b_i = self.K_b_i[:i+1]


### PR DESCRIPTION
I have added two different "ways" for computing the Jacobian in a more efficient way. The code applies automatically the selected scheme with the following priority: 

userJacobian (if userJacobian function is provided) -> multipleProfiles Jacobian (if multipleForwardKArgs is provided) -> Previous version of Jacobian (if none of the new inputs is provided)

The two new capabilities are:

1) Use the capability of most forward models to simulate several input profiles at the same time: so instead of looping through the perturbed profiles, the forward model is called once for all the perturbed profiles; this simply uses any under the hood optimizations of the forward solver. Requires arguments to set up the forward model for multiple profiles (we call them multipleForwardKwArgs)

2) If the user has its own function to compute Jacobians in a better way, they can provide it in the same way as for the forward model. This exploits the fact that most forward models include efficient ways to compute Jacobians using the same internal data structures as the forward model. Requires the function definition (e.g. similar to the forward function definition, we call it userJacobian)

Best, 
Mario