### PR TITLE
Added dtype to xtruth series creation

### DIFF
--- a/pyOptimalEstimation/pyOEcore.py
+++ b/pyOptimalEstimation/pyOEcore.py
@@ -216,7 +216,7 @@ class optimalEstimation(object):
         self.y_n = len(self.y_vars)
         self.forward = forward
         self.userJacobian = userJacobian
-        self.x_truth = pd.Series(x_truth, index=self.x_vars)
+        self.x_truth = pd.Series(x_truth, index=self.x_vars, dtype=np.float64)
 
         # We want to save at least the name because the forward function
         # is removed for saving


### PR DESCRIPTION
When using pyOptimalEstimation and we do NOT provide xtruth, a Pandas warning appears constantly on screen (this is regarding a default dtype that will no longer be float64 in the future). We add here then the dtype to the creation of the xtruth series (np.float64). 